### PR TITLE
fix: add check for _id to stop error when live previewing

### DIFF
--- a/components/PageBuilder/Logos.tsx
+++ b/components/PageBuilder/Logos.tsx
@@ -35,7 +35,7 @@ export default function PageBuilderLogos(props: PageBuilderLogosProps) {
 
         <div className="flex flex-wrap items-center justify-center gap-3 lg:gap-5">
           {logos.map((company) => (
-            <Logo key={company._id} company={company} />
+            <Logo key={company?._id} company={company} />
           ))}
         </div>
       </Container>


### PR DESCRIPTION
Just a simple fix for the split second when an `_id` isn't available on a logo.